### PR TITLE
Updated requirements for laravel 5.1. Because 5.1 requires php 5.5.9,…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
-    "illuminate/support": "5.0.*",
+    "php": ">=5.5.9",
+    "illuminate/support": "5.1.*",
     "imagine/imagine": "0.*"
   },
   "require-dev": {


### PR DESCRIPTION
… I set that as a requirement also.
