### PR TITLE
Update to support Laravel 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Upload image using Laravel's build in function and resize it using [Imagine libr
 
 ## Compatibility
 
-* Laravel 5.2 (Latest)
+* Laravel 5.4 (Latest)
 * Laravel 5.1 (LTS)
 * [Laravel 5.0](https://github.com/matriphe/laravel-imageupload/blob/laravel50/README.md)
 * [Laravel 4.2](https://github.com/matriphe/laravel-imageupload/blob/laravel42/README.md)

--- a/src/Matriphe/Imageupload/ImageuploadServiceProvider.php
+++ b/src/Matriphe/Imageupload/ImageuploadServiceProvider.php
@@ -22,7 +22,7 @@ class ImageuploadServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app['imageupload'] = $this->app->share(function($app)
+        $this->app->singleton('imageupload', function($app)
         {
             return new Imageupload();
         });


### PR DESCRIPTION
I modified the service provider to use the `singleton()` function since the `shared()` and `bindShared()` functions have been removed in Laravel 5.4.