### PR TITLE
Resized image is not being saved

### DIFF
--- a/src/Imageupload.php
+++ b/src/Imageupload.php
@@ -310,6 +310,8 @@ class Imageupload
                 });
             }
 
+            $image->save($targetFilepath, $this->quality);
+
             return [
                 'path' => dirname($targetFilepath),
                 'dir' => $this->getRelativePath($targetFilepath),


### PR DESCRIPTION
After upgrading to the latest version of the library we were not seeing any resized images being saved.  This fixes the issue for us.  Let me know if we are doing something wrong saving resized images!